### PR TITLE
Fix Amiri domain for compatability with SSL cert

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ libre fonts.
 
 Amiri
 -----
-[Website](https://amirifont.org), [GitHub](https://github.com/alif-type/amiri)
+[Website](https://www.amirifont.org), [GitHub](https://github.com/alif-type/amiri)
 
 Rana Kufi
 ---------


### PR DESCRIPTION
Current SSL cert is not registered with bare domain name, it
only works with *www* subdomain.